### PR TITLE
Refactor Xe.CLI module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+xe

--- a/lib/xe.ex
+++ b/lib/xe.ex
@@ -16,7 +16,7 @@ defmodule Xe do
       |> parse_res
   end
 
-  def parse_res([head, _ | tail]), do: {:error, [nil, nil]}
+  def parse_res([_head, _ | _tail]), do: {:error, [nil, nil]}
   def parse_res([head | []]) do
     case head do
       {"tr", _, tds} -> {:ok, fetch_values(tds) }

--- a/lib/xe/cli.ex
+++ b/lib/xe/cli.ex
@@ -1,12 +1,11 @@
 defmodule Xe.CLI do
 
-  @default_to "US"
+  @default_to "USD"
 
   def main(argv) do
     argv
-      |> parse_args
-      |> Xe.fetch
-      |> print_values
+    |> parse_args
+    |> process
   end
 
   def parse_args(argv) do
@@ -27,11 +26,17 @@ defmodule Xe.CLI do
     System.halt(0)
   end
 
-  def print_values({:ok, values}) do
+  def process(input = {_from, _to}) do
+    input
+    |> Xe.fetch
+    |> print_values
+  end
+
+  defp print_values({:ok, values}) do
     IO.puts(values)
   end
 
-  def print_values({:error, _}) do
+  defp print_values({:error, _}) do
     IO.puts("ERROR")
   end
 end

--- a/test/cli_test.exs
+++ b/test/cli_test.exs
@@ -11,7 +11,7 @@ defmodule CliTest do
     assert parse_args(["BR", "EUR"]) == { "BR", "EUR" }
   end
 
-  test "to is default to US if one value is given" do
-    assert parse_args(["BR"]) == { "BR", "US" }
+  test "to is default to USD if one value is given" do
+    assert parse_args(["BR"]) == { "BR", "USD" }
   end
 end


### PR DESCRIPTION
- Change module attribute `@default_to` to `USD` in Xe.CLI module since there is no `US` currency so the result will always return `0.00 0.00`
- Refactor `main/1` function in Xe.CLI module so that it can print helping message if we passs `--help` flag like; `./xe --help`
